### PR TITLE
Bugfix/only enable team repository when toggle is set

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ Available variables are listed below, along with their default values:
 - `enforce_admins` defaults to `true`
 - `req_pr_reviews_dismiss_stale_reviews` defaults to `true`
 
+Please note: `auto_init`, `gitignore_template` as well as `license_template` are actions that will result in commits being made to the GitHub Repository. These commits will be attributed to the user that is linked to the token that is used for the GitHub provider.
+
 ### Module outputs
 
 Available outputs are listed below, along with their description

--- a/README.md
+++ b/README.md
@@ -24,10 +24,10 @@ This module depends on a correctly configured [GitHub Provider](https://www.terr
 Add the module to your Terraform resources like so:
 
 ```hcl
-module "github-repository-my-website" {
+module "foo-cli" {
   source                               = "github.com/withmethod/terraform-module-github-repository?ref=0.3.1"
-  name                                 = "my-website"
-  description                          = "My Website"
+  name                                 = "foo-cli"
+  description                          = "foo CLI"
   homepage_url                         = "https://withmethod.com/open-source/"
   private                              = true
   has_issues                           = true
@@ -43,7 +43,7 @@ module "github-repository-my-website" {
   team_repository_team                 = "${github_team.internal.id}"
   team_repository_permission           = "pull"
   branch                               = "master"
-  enable_branch_protection             = 1 // only works after initial creation of repositry
+  enable_branch_protection             = 1 // only works after initial creation of repository
   enforce_admins                       = true
   req_status_checks_strict             = false
   req_status_checks_context            = ["continuous-integration/travis-ci"]

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Add the module to your Terraform resources like so:
 
 ```hcl
 module "github-repository-my-website" {
-  source                               = "github.com/withmethod/terraform-module-github-repository"
+  source                               = "github.com/withmethod/terraform-module-github-repository?ref=0.3.1"
   name                                 = "my-website"
   description                          = "My Website"
   homepage_url                         = "https://withmethod.com/open-source/"

--- a/README.md
+++ b/README.md
@@ -92,7 +92,6 @@ Available variables are listed below, along with their default values:
 
 - `private` defaults to `true`
 - `has_downloads` defaults to `false`
-- `gitignore_template` defaults to `Linux,macOS,Windows`
 - `license_template` defaults to `apache-2.0`
 - `branch` defaults to `master`
 - `enforce_admins` defaults to `true`

--- a/main.tf
+++ b/main.tf
@@ -15,6 +15,8 @@ resource "github_repository" "repository" {
 }
 
 resource "github_team_repository" "team-repository" {
+  count = "${var.enable_team_repository}"
+
   team_id    = "${var.team_repository_team}"
   repository = "${github_repository.repository.name}"
   permission = "${var.team_repository_permission}"

--- a/main.tf
+++ b/main.tf
@@ -37,11 +37,11 @@ resource "github_branch_protection" "protected-branch" {
   required_pull_request_reviews {
     dismiss_stale_reviews = "${var.req_pr_reviews_dismiss_stale_reviews}"
     dismissal_users       = "${var.req_pr_reviews_dismissal_users}"
-    dismissal_teams       = ["${var.req_pr_reviews_dismissal_teams}"]
+    dismissal_teams       = "${var.req_pr_reviews_dismissal_teams}"
   }
 
   restrictions {
     users = "${var.restrictions_users}"
-    teams = ["${var.restrictions_teams}"]
+    teams = "${var.restrictions_teams}"
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -59,7 +59,7 @@ variable "auto_init" {
 variable "gitignore_template" {
   type        = "string"
   description = "Set to a template to use for the `.gitignore` file"
-  default     = "Global/Linux,Global/macOS,Global/Windows"
+  default     = ""
 }
 
 variable "license_template" {


### PR DESCRIPTION
Noticed a bug in `0.3.0` that would always create team repository resources, even if the toggle was set to `0`.

This change fixes that and additionally updates the `source` URL in `README.md` to reflect the suggested upstream path.

[EDIT]

As it went, I've added a few more improvements to this PR, namely:

- default `gitignore_template` to empty string as `Global/*` properties do not work and referencing them like I did in `variables.tf` and `README.md` was actually incorrect
- add notice to `README.md` that using `auto_init`, `license_template` or `gitignore_template` will result in commit(s) being made to the repository at hand

Once done, I'll release this as `0.3.1`.