### PR TITLE
empty .gitignore template and an extra note in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,11 +92,12 @@ Available variables are listed below, along with their default values:
 
 - `private` defaults to `true`
 - `has_downloads` defaults to `false`
-- `gitignore_template` defaults to `Linux,macOS,Windows`
 - `license_template` defaults to `apache-2.0`
 - `branch` defaults to `master`
 - `enforce_admins` defaults to `true`
 - `req_pr_reviews_dismiss_stale_reviews` defaults to `true`
+
+Please note: `auto_init`, `gitignore_template` as well as `license_template` are actions that will result in commits being made to the GitHub Repository. These commits will be attributed to the user that is linked to the token that is used for the GitHub provider.
 
 ### Module outputs
 

--- a/variables.tf
+++ b/variables.tf
@@ -59,7 +59,7 @@ variable "auto_init" {
 variable "gitignore_template" {
   type        = "string"
   description = "Set to a template to use for the `.gitignore` file"
-  default     = "Global/Linux,Global/macOS,Global/Windows"
+  default     = ""
 }
 
 variable "license_template" {


### PR DESCRIPTION
Do not default to a non-working string in `gitignore_template`