### PR TITLE
Include permission in type for team_repository_teams

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Additional usage examples are available in the `examples` directory via [GitHub]
 | pages | Configuration block for GitHub Pages | `map(any)` | `{}` |
 | projects | List of Project Objecs | <pre>list(object({<br>    name = string,<br>    body = string<br>  }))</pre> | `[]` |
 | repository_collaborators | List of Collaborator Objects | <pre>list(object({<br>    username = string<br>  }))</pre> | `[]` |
-| team_repository_teams | List of Team Repository Team Objects | <pre>list(object({<br>    team_id = string<br>  }))</pre> | `[]` |
+| team_repository_teams | List of Team Repository Team Objects | <pre>list(object({<br>    team_id = string,<br>    permission = string<br>  }))</pre> | `[]` |
 | template | Template Repository to use when creating the Repository | `map(string)` | `{}` |
 | topics | List of Topics of the Repository | `list(string)` | `[]` |
 | visibility | Toggle to create a Private Repository | `string` | `"private"` |


### PR DESCRIPTION
This PR is to:
- update the type for `team_repository_teams` in the README to specify that 

It would be good to also mention that `permission` value must be one of `pull`, `triage`, `push`, `maintain`, or `admin`. Defaults to `pull`. 

Or add a link to [the provider docs](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/team_repository#permission). I'm not sure where you would put that though.