### PR TITLE
Update README Links

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ module "simple_example" {
 
 Then, fetch the module from the [Terraform Registry](https://registry.terraform.io/modules/operatehappy/repository/github) using `terraform get`.
 
-Additional usage examples are available in the `examples` directory via [GitHub](https://github.com/operatehappy/terraform-github-repository/tree/main/examples).
+Additional usage examples are available in the `examples` directory via [GitHub](https://github.com/operatehappy/terraform-github-repository/tree/master/examples).
 
 ### Inputs
 

--- a/examples/branch_protection/README.md
+++ b/examples/branch_protection/README.md
@@ -57,4 +57,4 @@ module "branch_protection_example" {
 
 For a list of available variables and outputs, see the [Readme document](https://registry.terraform.io/modules/operatehappy/repository/github) on the Terraform Registry.
 
-A copy of this document (as `README.md`) is also available on [GitHub](https://github.com/operatehappy/terraform-github-repository/blob/main/README.md#readme).
+A copy of this document (as `README.md`) is also available on [GitHub](https://github.com/operatehappy/terraform-github-repository/blob/master/README.md#readme).

--- a/examples/complex/README.md
+++ b/examples/complex/README.md
@@ -44,4 +44,4 @@ module "complex_example" {
 
 For a list of available variables and outputs, see the [Readme document](https://registry.terraform.io/modules/operatehappy/repository/github) on the Terraform Registry.
 
-A copy of this document (as `README.md`) is also available on [GitHub](https://github.com/operatehappy/terraform-github-repository/blob/main/README.md#readme).
+A copy of this document (as `README.md`) is also available on [GitHub](https://github.com/operatehappy/terraform-github-repository/blob/master/README.md#readme).

--- a/examples/deploy_keys/README.md
+++ b/examples/deploy_keys/README.md
@@ -39,4 +39,4 @@ module "deploy_keys_example" {
 
 For a list of available variables and outputs, see the [Readme document](https://registry.terraform.io/modules/operatehappy/repository/github) on the Terraform Registry.
 
-A copy of this document (as `README.md`) is also available on [GitHub](https://github.com/operatehappy/terraform-github-repository/blob/main/README.md#readme).
+A copy of this document (as `README.md`) is also available on [GitHub](https://github.com/operatehappy/terraform-github-repository/blob/master/README.md#readme).

--- a/examples/files/README.md
+++ b/examples/files/README.md
@@ -41,4 +41,4 @@ module "files_example" {
 
 For a list of available variables and outputs, see the [Readme document](https://registry.terraform.io/modules/operatehappy/repository/github) on the Terraform Registry.
 
-A copy of this document (as `README.md`) is also available on [GitHub](https://github.com/operatehappy/terraform-github-repository/blob/main/README.md#readme).
+A copy of this document (as `README.md`) is also available on [GitHub](https://github.com/operatehappy/terraform-github-repository/blob/master/README.md#readme).

--- a/examples/issue_labels/README.md
+++ b/examples/issue_labels/README.md
@@ -49,4 +49,4 @@ module "issue_labels_example" {
 
 For a list of available variables and outputs, see the [Readme document](https://registry.terraform.io/modules/operatehappy/repository/github) on the Terraform Registry.
 
-A copy of this document (as `README.md`) is also available on [GitHub](https://github.com/operatehappy/terraform-github-repository/blob/main/README.md#readme).
+A copy of this document (as `README.md`) is also available on [GitHub](https://github.com/operatehappy/terraform-github-repository/blob/master/README.md#readme).

--- a/examples/project/README.md
+++ b/examples/project/README.md
@@ -38,4 +38,4 @@ module "project_example" {
 
 For a list of available variables and outputs, see the [Readme document](https://registry.terraform.io/modules/operatehappy/repository/github) on the Terraform Registry.
 
-A copy of this document (as `README.md`) is also available on [GitHub](https://github.com/operatehappy/terraform-github-repository/blob/main/README.md#readme).
+A copy of this document (as `README.md`) is also available on [GitHub](https://github.com/operatehappy/terraform-github-repository/blob/master/README.md#readme).

--- a/examples/project_columns/README.md
+++ b/examples/project_columns/README.md
@@ -68,4 +68,4 @@ In spite of that, the module output for `project_ids` is used to iterate over, w
 
 For a list of available variables and outputs, see the [Readme document](https://registry.terraform.io/modules/operatehappy/repository/github) on the Terraform Registry.
 
-A copy of this document (as `README.md`) is also available on [GitHub](https://github.com/operatehappy/terraform-github-repository/blob/main/README.md#readme).
+A copy of this document (as `README.md`) is also available on [GitHub](https://github.com/operatehappy/terraform-github-repository/blob/master/README.md#readme).

--- a/examples/simple/README.md
+++ b/examples/simple/README.md
@@ -31,4 +31,4 @@ module "simple_example" {
 
 For a list of available variables and outputs, see the [Readme document](https://registry.terraform.io/modules/operatehappy/repository/github) on the Terraform Registry.
 
-A copy of this document (as `README.md`) is also available on [GitHub](https://github.com/operatehappy/terraform-github-repository/blob/main/README.md#readme).
+A copy of this document (as `README.md`) is also available on [GitHub](https://github.com/operatehappy/terraform-github-repository/blob/master/README.md#readme).


### PR DESCRIPTION
READMEs within the repositories link to one another however the links were broken due to references pointing to `main` rather than the current primary branch of `master`. At the moment while the primary branch is `master` we should update the documents to fix the broken links avoiding 404s.