### PR TITLE
Fix #26: Set Default integrations/github for Module

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This module requires Terraform version `0.14.0` or newer.
 
 ## Dependencies
 
-This module depends on a correctly configured [GitHub Provider](https://www.terraform.io/docs/providers/github/index.html) in your Terraform codebase.
+This module depends on a correctly configured [GitHub Provider](https://www.terraform.io/docs/providers/github/index.html) in your Terraform codebase with a minimum version of `4.4.0`.
 
 ## Usage
 

--- a/terraform.tf
+++ b/terraform.tf
@@ -1,3 +1,10 @@
 terraform {
+  required_providers {
+    github = {
+      source  = "integrations/github"
+      version = ">= 4.4.0"
+    }
+  }
+
   required_version = ">= 0.14.0"
 }


### PR DESCRIPTION
As outlined in #26, there is a bug in the GitHub provider causing any references within modules to use the older version `hashicorp/github` rather than `integrations/github`. We can encourage users to use the latest provider by setting a default.

Worse case, they are using `hashicorp/github` and therefore both providers are downloaded and initialized (which is what is happening now). Alternatively, those that are using the newer provider instance will now only download the newer one. The existing documentation in this repository suggests using the newer instance of the provider, so setting a default doesn't seem so bad.

The exact version of the newer provider is up to the version outlined by those using the module with the proviso it is greater than `4.4.0`.

Fixes #26 
