### PR TITLE
fix #34: add support for web_commit_signoff_required

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Additional usage examples are available in the `examples` directory via [GitHub]
 | topics | List of Topics of the Repository. | `list(string)` | `null` | no |
 | visibility | Toggle to set the visibility of the Repository. | `string` | `"private"` | no |
 | vulnerability_alerts | Toggle to enable Vulnerability Alerts for the Repository. | `bool` | `true` | no |
+| web_commit_signoff_required | Toggle to require contributors to sign off on web-based commits. | `bool` | `false` | no |
 
 ### Outputs
 

--- a/examples/complex/main.tf
+++ b/examples/complex/main.tf
@@ -1,20 +1,21 @@
 module "complex_example" {
   source = "../.."
 
-  name               = "complex-example"
-  description        = "Complex Repository Example"
-  homepage_url       = "https://github.com/ksatirli"
-  visibility         = "private"
-  has_issues         = true
-  has_projects       = true
-  has_wiki           = false
-  allow_merge_commit = false
-  allow_squash_merge = true
-  allow_rebase_merge = false
-  has_downloads      = false
-  auto_init          = true
-  default_branch     = "main"
-  archived           = false
+  name                        = "complex-example"
+  description                 = "Complex Repository Example"
+  homepage_url                = "https://github.com/ksatirli"
+  visibility                  = "private"
+  has_issues                  = true
+  has_projects                = true
+  has_wiki                    = false
+  allow_merge_commit          = false
+  allow_squash_merge          = true
+  allow_rebase_merge          = false
+  has_downloads               = false
+  auto_init                   = true
+  default_branch              = "main"
+  archived                    = false
+  web_commit_signoff_required = true
 
   topics = [
     "topic-1",

--- a/main.tf
+++ b/main.tf
@@ -1,24 +1,25 @@
 # see https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository
 resource "github_repository" "main" {
-  name                   = var.name
-  description            = var.description
-  homepage_url           = var.homepage_url
-  visibility             = var.visibility
-  has_issues             = var.has_issues
-  has_projects           = var.has_projects
-  has_wiki               = var.has_wiki
-  is_template            = var.is_template
-  allow_merge_commit     = var.allow_merge_commit
-  allow_squash_merge     = var.allow_squash_merge
-  allow_rebase_merge     = var.allow_rebase_merge
-  allow_auto_merge       = var.allow_auto_merge
-  delete_branch_on_merge = var.delete_branch_on_merge
-  has_downloads          = var.has_downloads
-  auto_init              = var.auto_init
-  gitignore_template     = var.gitignore_template
-  license_template       = var.license_template
-  archived               = var.archived
-  archive_on_destroy     = var.archive_on_destroy
+  name                        = var.name
+  description                 = var.description
+  homepage_url                = var.homepage_url
+  visibility                  = var.visibility
+  has_issues                  = var.has_issues
+  has_projects                = var.has_projects
+  has_wiki                    = var.has_wiki
+  is_template                 = var.is_template
+  allow_merge_commit          = var.allow_merge_commit
+  allow_squash_merge          = var.allow_squash_merge
+  allow_rebase_merge          = var.allow_rebase_merge
+  allow_auto_merge            = var.allow_auto_merge
+  delete_branch_on_merge      = var.delete_branch_on_merge
+  has_downloads               = var.has_downloads
+  auto_init                   = var.auto_init
+  gitignore_template          = var.gitignore_template
+  license_template            = var.license_template
+  archived                    = var.archived
+  archive_on_destroy          = var.archive_on_destroy
+  web_commit_signoff_required = var.web_commit_signoff_required
 
   dynamic "pages" {
     for_each = length(var.pages) != 0 ? [var.pages] : []
@@ -47,8 +48,8 @@ resource "github_repository" "main" {
 
 # see https://registry.terraform.io/providers/integrations/github/latest/docs/resources/branch_default
 resource "github_branch_default" "main" {
- repository = github_repository.main.name
- branch     = var.default_branch
+  repository = github_repository.main.name
+  branch     = var.default_branch
 }
 
 # TODO

--- a/variables.tf
+++ b/variables.tf
@@ -252,3 +252,9 @@ variable "files" {
   description = "List of File Objects."
   default     = []
 }
+
+variable "web_commit_signoff_required" {
+  type        = bool
+  description = "Toggle to require contributors to sign off on web-based commits."
+  default     = false
+}


### PR DESCRIPTION
Added support for [web_commit_signoff_required](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository#web_commit_signoff_required-1) with a default value of `false` to match provider.

Added configuration to example `examples/complex/main.tf` to be ran by `workflows/terraform.yml`.

Updated `README.md` to include the new option.

fixes #34